### PR TITLE
refactor: add tasks modal to the right route

### DIFF
--- a/src/components/pages/ExplorerPage/ExplorerPage.tsx
+++ b/src/components/pages/ExplorerPage/ExplorerPage.tsx
@@ -32,10 +32,6 @@ const ExplorerPage: React.FC = () => {
     return <p>You don{"'"}t have any projects yet...</p>;
   }
 
-  if (location.pathname === "/explorer") {
-    return <Redirect to={`/explorer/${auth.currentProjectId}/shots`} />;
-  }
-
   return (
     <Box p={8} height="100%">
       <Box sx={{ display: "flex", alignItems: "center" }}>
@@ -75,21 +71,24 @@ const ExplorerPage: React.FC = () => {
 
       <Box sx={{ mt: 4 }}>
         <Switch>
-          <Route path={`/explorer/:projectId/shots/:shotId`}>
-            <TasksView listView={listView} />
+          {/* Redirect to the shots by default when we go to the explorer */}
+          <Route exact path={`/explorer`}>
+            <Redirect to={`/explorer/${auth.currentProjectId}/shots`} />
           </Route>
 
-          <Route path={`/explorer/:projectId/shots`}>
-            <ShotsView listView={listView} />
-          </Route>
+          <Switch>
+            <Route path={`/explorer/:projectId/:category/:entityId/tasks`}>
+              <TasksView listView={listView} />
+            </Route>
 
-          <Route path={`/explorer/:projectId/assets/:assetId`}>
-            <TasksView listView={listView} />
-          </Route>
+            <Route path={`/explorer/:projectId/shots`}>
+              <ShotsView listView={listView} />
+            </Route>
 
-          <Route path={`/explorer/:projectId/assets`}>
-            <AssetsView listView={listView} />
-          </Route>
+            <Route path={`/explorer/:projectId/assets`}>
+              <AssetsView listView={listView} />
+            </Route>
+          </Switch>
         </Switch>
       </Box>
     </Box>

--- a/src/components/pages/ExplorerPage/views/EntityItem.tsx
+++ b/src/components/pages/ExplorerPage/views/EntityItem.tsx
@@ -58,7 +58,11 @@ const EntityItem: React.FC<EntityItemProps> = ({
   const onClickAction = () => {
     openTaskModal
       ? openTaskModal(entity.id)
-      : history.push(`${routeMatch.url}/${entity.id}`);
+      : history.push(
+          `${routeMatch.url}/${entity.id}${
+            entity.type === "Shot" ? "/tasks" : ""
+          }`
+        );
   };
 
   return (

--- a/src/components/pages/ExplorerPage/views/TaskModal.tsx
+++ b/src/components/pages/ExplorerPage/views/TaskModal.tsx
@@ -9,6 +9,7 @@ import {
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import { gql, useQuery } from "@apollo/client";
+import { useHistory, useRouteMatch } from "react-router-dom";
 
 import { Task } from "types";
 import QueryWrapper from "components/QueryWrapper/QueryWrapper";
@@ -44,14 +45,17 @@ const TASK = gql`
   }
 `;
 
-interface TaskModalProps {
-  taskId: string;
-  onClose: () => void;
-}
+const TaskModal: React.FC = () => {
+  const routeMatch = useRouteMatch<{ taskId: string }>();
 
-const TaskModal: React.FC<TaskModalProps> = ({ taskId, onClose }) => {
+  const history = useHistory();
+
+  const onClose = () => {
+    history.goBack();
+  };
+
   const query = useQuery<{ task: Task }>(TASK, {
-    variables: { id: taskId },
+    variables: { id: routeMatch.params.taskId },
   });
   const { data } = query;
 


### PR DESCRIPTION
This PR does the following:

- The task view is in `/explorer/:projectId/:category/:entityId/tasks`
- The modal is in `tasks/:taskId`